### PR TITLE
fix: windows-chrome screen sharing delay issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 node_modules/
 *.lock
+.DS_Store

--- a/src/IrisRtcDeviceManager.ts
+++ b/src/IrisRtcDeviceManager.ts
@@ -343,6 +343,8 @@ class IrisLocalTrackManager extends IrisVideoTrackManager {
     if (this.screenConfig !== undefined) {
       this.localVideoTrack?.close();
       this.localVideoTrack = undefined;
+      this.localAudioTrack?.close();
+      this.localAudioTrack = undefined;
       this.screenConfig = undefined;
     }
   }

--- a/src/IrisRtcEngine.ts
+++ b/src/IrisRtcEngine.ts
@@ -535,6 +535,9 @@ export default class IrisRtcEngine {
 
   private _createClient() {
     if (this._client !== undefined) return;
+    console.log('DELDEL _createClient');
+    this._config.codec = 'vp8';
+    this._config.audioCodec = 'opus';
     this._client = AgoraRTC.createClient(this._config);
     this._addListener();
   }

--- a/src/IrisRtcEngine.ts
+++ b/src/IrisRtcEngine.ts
@@ -1341,12 +1341,12 @@ export default class IrisRtcEngine {
       if (this._iLocalScreenCaptureTrack) {
         this._client?.unpublish(this._iLocalScreenCaptureTrack);
         if (typeof this._iLocalScreenCaptureTrack.close === 'function') {
-          /// called when tab is sharing without audio
+          /// called when Chrome tab is sharing without audio or Widow or Full screen
           this._iLocalScreenCaptureTrack.close();
         } else {
-          /// called when tab is sharing with audio
-          /// TODO: later we should handle this case
-          console.log('DELDEL iris customStopLocalScreenCaptureTrack else');
+          /// called when Chrome tab is sharing with audio (and video)
+          this._iLocalScreenCaptureTrack[0].close();
+          this._iLocalScreenCaptureTrack[1].close();
         }
       }
     } catch (e) {

--- a/src/IrisRtcEngine.ts
+++ b/src/IrisRtcEngine.ts
@@ -1355,16 +1355,16 @@ export default class IrisRtcEngine {
   }
 
   private async customRestoreLocalTrackAndPublish(): Promise<void> {
-    // 추후 사용 가능성을 대비해 주석처리 함
-    // await this.deviceManager
-    //   .createMicrophoneAudioTrack(
-    //     this._enableAudio && this._enableLocalAudio,
-    //     this._emitEvent.bind(this),
-    //     true
-    //   )
-    //   .then((track) => {
-    //     this._iLocalAudioTrack = track;
-    //   });
+    /// 화면 공유의 오디오 공유(크롬 탭) 종료 후 호스트의 오디오 트랙을 재생성
+    await this.deviceManager
+      .createMicrophoneAudioTrack(
+        this._enableAudio && this._enableLocalAudio,
+        this._emitEvent.bind(this),
+        true
+      )
+      .then((track) => {
+        this._iLocalAudioTrack = track;
+      });
     await this.deviceManager
       .createCameraVideoTrack(
         this._enableVideo && this._enableLocalVideo,


### PR DESCRIPTION
## Overview
- 환경: Windows-chrome 
- 화면 공유 시 공유되는 화면 송출 delay(수분) 이슈
- h.264 codec의 영향으로 판단
- agora에서도 h.264 보다는 vp8을 비디오 코덱으로 추천